### PR TITLE
Add Zephyr Photo Credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ yarn && yarn dev
 
 ## Attribution
 
+Hacker Zephyr photos by [Kunal Botla](https://kunalbotla.com) under a [media license](https://github.com/kunalbotla/photos/blob/main/LICENSE.md). 
+
 The Skyline background image was designed by and courtesy of [Vexels](https://www.vexels.com) under a CC-BY-3.0 license.
 
 The halftone images were generated using https://mrmotarius.itch.io/mrmo-halftone.

--- a/components/features.js
+++ b/components/features.js
@@ -47,7 +47,7 @@ export const Features = () => (
           // src="https://cloud-me9ijbqml-hack-club-bot.vercel.app/0hibernia.png"
           src="https://cloud-e57ekrxp4-hack-club-bot.vercel.app/0shareknowledge.jpg"
           href="https://cloud-j0br81ugp-hack-club-bot.vercel.app/0zephyr5.jpg"
-          alt="Two hackers problem-solving on the Hacker Zephyr"
+          alt="Two hackers problem-solving on the Hacker Zephyr (Photo by Kunal Botla)"
           objectPosition="left bottom"
         />
         <InfoBox
@@ -73,7 +73,7 @@ export const Features = () => (
             }}
             src="https://cloud-j0br81ugp-hack-club-bot.vercel.app/3zephyr2.jpg"
             href="https://cloud-j0br81ugp-hack-club-bot.vercel.app/3zephyr2.jpg"
-            alt="Teenager coding on The Hacker Zephyr"
+            alt="Teenager coding on The Hacker Zephyr (Photo by Kunal Botla)"
           />
         </Box>
         <InfoBox iconGlyph="announcement" heading="Set New Standards">

--- a/components/footer.js
+++ b/components/footer.js
@@ -39,6 +39,14 @@ const Footer = () => (
         >
           hackclub/www-assemble
         </Link>.
+        Hacker Zephyr photos by{' '}
+        <Link
+          href="https://kunalbotla.com"
+          sx={{ color: 'white', fontWeight: 800 }}
+          target="_blank"
+        >
+          Kunal Botla
+        </Link>.
       </Box>
       {/* only uncomment this once the bank project is in transparency mode & the site repo is public */}
 


### PR DESCRIPTION
add photo credits and retroactive permission to use the photos, as required by my [media license](https://github.com/kunalbotla/photos/blob/main/LICENSE.md), the license these photos were provided with. thanks!